### PR TITLE
Fix build errors

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,8 @@
 pkg = import('pkgconfig')
 pango_dep = dependency('pangoft2')
 cairo_dep = dependency('pangocairo')
+glib_dep = dependency('glib-2.0')
+gobject_dep = dependency('gobject-2.0')
 
 paps_config = configuration_data()
 
@@ -31,5 +33,5 @@ paps = executable('paps',
                   ['paps.c'],
                   c_args: ['-DHAVE_CONFIG_H'],
                   include_directories: incs,
-                  dependencies : [pango_dep, cairo_dep],
+                  dependencies : [pango_dep, cairo_dep, glib_dep, gobject_dep],
                   install: true)

--- a/src/paps.c
+++ b/src/paps.c
@@ -34,10 +34,17 @@
 #include <string.h>
 #include <time.h>
 #include <locale.h>
-#include <math.h>
-#include <wchar.h>
 #include <libgen.h>
 #include <config.h>
+
+#define _XOPEN_SOURCE /* for wcwidth */
+#include <wchar.h>
+int wcwidth(wchar_t c);
+
+#ifndef M_PI
+#define __USE_XOPEN
+#endif
+#include <math.h>
 
 #if ENABLE_NLS
 #include <libintl.h>


### PR DESCRIPTION
Fix these errors:

../src/paps.c:983:38: warning: implicit declaration of function ‘wcwidth’ [-Wimplicit-function-declaration]

../src/paps.c:1291:30: error: ‘M_PI’ undeclared (first use in this function); did you mean ‘G_PI’?

/bin/ld: src/25a6634@@paps@exe/paps.c.o: undefined reference to symbol 'g_utf8_to_ucs4'
/bin/ld: /usr/lib/../lib/libglib-2.0.so.0: error adding symbols: DSO missing from command line

/bin/ld: src/25a6634@@paps@exe/paps.c.o: undefined reference to symbol 'g_type_check_instance_cast'
/bin/ld: /usr/lib/../lib/libgobject-2.0.so.0: error adding symbols: DSO missing from command line