### PR TITLE
Get paper sizes with libpaper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@
 /intltool-merge.in
 /intltool-update.in
 /libtool
+/m4/libtool.m4
+/m4/lt*.m4
 /po/*.gmo
 /po/*.mo
 /po/.intltool-merge-cache

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 /config
 /config.cache
 /config.h
+/config.h.in
 /config.log
 /config.lt
 /config.status

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,7 @@
 dnl Process this file with autoconf to produce a configuration script
 AC_INIT(paps, 0.8.0, dov.grobgeld@gmail.com)
 AC_CONFIG_AUX_DIR(config)
+AC_CONFIG_MACRO_DIRS([m4])
 AC_CONFIG_SRCDIR(src/paps.cc)
 AC_CONFIG_HEADERS([config.h])
 
@@ -20,6 +21,7 @@ PKG_CHECK_MODULES(FMT, fmt >= 6.0)
 AC_SUBST(FMT_CFLAGS)
 AC_SUBST(FMT_LIBS)
 AC_PROG_INTLTOOL([0.23])
+LT_INIT
 
 GETTEXT_PACKAGE=paps
 AC_SUBST(GETTEXT_PACKAGE)

--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,10 @@ AC_SUBST(FMT_LIBS)
 AC_PROG_INTLTOOL([0.23])
 LT_INIT
 
+ad_FUNC_SYSTEMPAPERNAME
+AS_IF([test "$ac_cv_lib_paper_systempapername" = "no" -o "$ac_cv_header_paper_h" = "no"],
+  [AC_MSG_ERROR([paps needs libpaper to work])])
+
 GETTEXT_PACKAGE=paps
 AC_SUBST(GETTEXT_PACKAGE)
 AC_DEFINE_UNQUOTED([GETTEXT_PACKAGE], ["$GETTEXT_PACKAGE"], [Package name for gettext.])

--- a/m4/libpaper.m4
+++ b/m4/libpaper.m4
@@ -1,0 +1,20 @@
+dnl ## --------------------------------------------------------- ##
+dnl ##  Check if libpaper is available                           ##
+dnl ##                           demaille@inf.enst.fr            ##
+dnl ## --------------------------------------------------------- ##
+dnl
+dnl
+
+# serial 1
+
+AC_DEFUN([ad_FUNC_SYSTEMPAPERNAME],
+[
+  AC_CHECK_LIB(paper, systempapername, 
+    dnl Action if found
+    [
+      AC_DEFINE([HAVE_SYSTEMPAPERNAME], 1,
+                [Define if you have the systempapername function])
+      LIBS="$LIBS -lpaper"
+      AC_CHECK_HEADERS(paper.h)
+    ])
+])


### PR DESCRIPTION
This PR adds the use of libpaper to get paper sizes. This enables support for a wide range of paper sizes, including user-defined sizes with libpaper 2 (but version 1 can also be used).