### PR TITLE
fix(src-to-paps): switch the script to Python 3

### DIFF
--- a/scripts/src-to-paps
+++ b/scripts/src-to-paps
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 ######################################################################
 #  Use GNU source-hightlight to turn source code into pango markup


### PR DESCRIPTION
Seems to be correct Python 3 script. Unfortunately, Python 2 shebang was generating for us false Python 2 dependency in our distribution.