### PR TITLE
Use portable shebang

### DIFF
--- a/scripts/src-to-paps
+++ b/scripts/src-to-paps
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 ######################################################################
 #  Use GNU source-highlight to turn source code into pango markup


### PR DESCRIPTION
Not all GNU/Linux distributions put Python interpreter at /usr/bin/python3. The cross-distribution way to write a Python shebang is usually to use /usr/bin/env python3.

@mcepl (I guess it's ok for OpenSuse too)